### PR TITLE
Fixed bug in Library.Common

### DIFF
--- a/src/AlfaBank.AFT.Core.Library.Common/AlfaBank.AFT.Core.Library.Common.csproj
+++ b/src/AlfaBank.AFT.Core.Library.Common/AlfaBank.AFT.Core.Library.Common.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>AlfaBank.AFT.Core.Library.Common</AssemblyName>
     <Authors>Egor Shokhin</Authors>
     <Company>AlfaBank</Company>
-    <Version>0.0.8</Version>
+    <Version>0.0.9</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
   </PropertyGroup>
@@ -20,8 +20,8 @@
     <IsPackable>true</IsPackable>
     <Description>Библиотека с общими шагами генерации уникальных данных, а также с универсальными проверками корректности значений</Description>
     <PackageTags>specflow common steps alfabank aft</PackageTags>
-    <AssemblyVersion>0.0.8.0</AssemblyVersion>
-    <FileVersion>0.0.8.0</FileVersion>
+    <AssemblyVersion>0.0.9.0</AssemblyVersion>
+    <FileVersion>0.0.9.0</FileVersion>
     <Copyright>2019 AlfaBank</Copyright>
     <RepositoryUrl>https://github.com/alfa-laboratory/AlfaBank.AFT.Core.Library</RepositoryUrl>
     <PackageProjectUrl>https://github.com/alfa-laboratory/AlfaBank.AFT.Core.Library</PackageProjectUrl>

--- a/src/AlfaBank.AFT.Core.Library.Common/CommonSteps.Steps.cs
+++ b/src/AlfaBank.AFT.Core.Library.Common/CommonSteps.Steps.cs
@@ -624,7 +624,7 @@ namespace AlfaBank.AFT.Core.Library.Common
         [StepDefinition(@"я сохраняю значение переменной ""(.+)"" в переменную ""(.+)""")]
         public void StoreVariableValueToVariable(string varName, string newVarName)
         {
-            this.variableContext.Variables.ContainsKey(varName).Should().BeTrue($"Переменной '{varName}' не существует");
+            this.variableContext.Variables.ContainsKey(this.variableContext.GetVariableName(varName)).Should().BeTrue($"Переменной '{varName}' не существует");
             this.variableContext.Variables.ContainsKey(newVarName).Should().BeFalse($"Переменная '{newVarName}' уже существует");
             var value = this.variableContext.GetVariableValue(varName);
             value.Should().NotBeNull($"Значения в переменной {varName} нет");


### PR DESCRIPTION
При сохранении переменной типа varname[index] или varname.//path, появлялась ошибка: "Переменной varname не существует".