### PR TITLE
Fixed generation random numbers bug

### DIFF
--- a/src/AlfaBank.AFT.Core/AlfaBank.AFT.Core.csproj
+++ b/src/AlfaBank.AFT.Core/AlfaBank.AFT.Core.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>AlfaBank.AFT.Core</AssemblyName>
     <Authors>Egor Shokhin</Authors>
     <Company>AlfaBank</Company>
-    <Version>0.0.18</Version>
+    <Version>0.0.19</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression></PackageLicenseExpression>
   </PropertyGroup>
@@ -19,8 +19,8 @@
     <IsPackable>true</IsPackable>
     <Description>Библиотека с логикой генераций уникальных текстовых, числовых значений; работы с базой данных; работой с веб-сервисами</Description>
     <PackageTags>specflow aft alfabank generate core</PackageTags>
-    <AssemblyVersion>0.0.18.0</AssemblyVersion>
-    <FileVersion>0.0.18.0</FileVersion>
+    <AssemblyVersion>0.0.19.0</AssemblyVersion>
+    <FileVersion>0.0.19.0</FileVersion>
     <Copyright>2019 AlfaBank</Copyright>
     <RepositoryUrl>https://github.com/alfa-laboratory/AlfaBank.AFT.Core.Library</RepositoryUrl>
     <PackageProjectUrl>https://github.com/alfa-laboratory/AlfaBank.AFT.Core.Library</PackageProjectUrl>

--- a/src/AlfaBank.AFT.Core/Helpers/DataGenerator.cs
+++ b/src/AlfaBank.AFT.Core/Helpers/DataGenerator.cs
@@ -9,6 +9,7 @@ namespace AlfaBank.AFT.Core.Helpers
         public static string UpperChars { get; } = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         public static string LowerChars { get; } = "abcdefghijklmnopqrstuvwxyz";
         public static string Numbers { get; } = "0123456789";
+        public static string NumbersWithoutZero { get; } = "123456789";
 
         public static string GetRandomStringWithPrefix(int len, string prefix)
         {
@@ -37,7 +38,7 @@ namespace AlfaBank.AFT.Core.Helpers
 
         public static string GetRandomNumbers(int len)
         {
-            return GetRandomString(len, Numbers);
+            return GetRandomString(1, NumbersWithoutZero) + GetRandomString(len - 1, Numbers);
         }
 
         public static string GetGuid()

--- a/src/AlfaBank.AFT.Core/Helpers/DataGenerator.cs
+++ b/src/AlfaBank.AFT.Core/Helpers/DataGenerator.cs
@@ -9,7 +9,6 @@ namespace AlfaBank.AFT.Core.Helpers
         public static string UpperChars { get; } = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         public static string LowerChars { get; } = "abcdefghijklmnopqrstuvwxyz";
         public static string Numbers { get; } = "0123456789";
-        public static string NumbersWithoutZero { get; } = "123456789";
 
         public static string GetRandomStringWithPrefix(int len, string prefix)
         {
@@ -38,7 +37,7 @@ namespace AlfaBank.AFT.Core.Helpers
 
         public static string GetRandomNumbers(int len)
         {
-            return len != 0 ? GetRandomString(1, NumbersWithoutZero) + GetRandomString(len - 1, Numbers) : "";
+            return len > 0 ? GetRandomString(1, Numbers.Remove(0, 1)) + GetRandomString(len - 1, Numbers) : "";
         }
 
         public static string GetGuid()

--- a/src/AlfaBank.AFT.Core/Helpers/DataGenerator.cs
+++ b/src/AlfaBank.AFT.Core/Helpers/DataGenerator.cs
@@ -38,7 +38,7 @@ namespace AlfaBank.AFT.Core.Helpers
 
         public static string GetRandomNumbers(int len)
         {
-            return GetRandomString(1, NumbersWithoutZero) + GetRandomString(len - 1, Numbers);
+            return len != 0 ? GetRandomString(1, NumbersWithoutZero) + GetRandomString(len - 1, Numbers) : "";
         }
 
         public static string GetGuid()


### PR DESCRIPTION
В методе GetRandomNumbers проверки len=0, len=1 будут лишними.
len=0 - неправильные данные, обрабатывается в шаге.
len=1 - проходит успешно, GetRandomString(0, Numbers) не генерирует число и не выдаёт ошибку.